### PR TITLE
add -lpthread to LD_FLAGS to fix build error on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ THIRD_PARTY_LIB = $(MULTIVERSO_DIR)/third_party/lib
 INC_FLAGS = -I$(MULTIVERSO_INC)
 LD_FLAGS  = -L$(MULTIVERSO_LIB) -lmultiverso
 LD_FLAGS += -L$(THIRD_PARTY_LIB) -lzmq -lmpich -lmpl
+LD_FLAGS += -lpthread
   	  	
 WORD_EMBEDDING_HEADERS = $(shell find $(PROJECT)/src -type f -name "*.h")
 WORD_EMBEDDING_SRC     = $(shell find $(PROJECT)/src -type f -name "*.cpp")


### PR DESCRIPTION
Build fails on Ubuntu 14.04 LTS:

    /usr/bin/ld: /home/swpd/distributed_word_embedding/multiverso/third_party/lib/libmpich.a(ch3_win_fns.o): undefined reference to symbol 'pthread_mutexattr_init@@GLIBC_2.2.5'

Fixed by adding `-lpthread` to `LD_FLAGS` in Makefile.